### PR TITLE
Fix uninitialized constant ImOrder::OrderNotVoidable

### DIFF
--- a/lib/order/error.rb
+++ b/lib/order/error.rb
@@ -42,7 +42,7 @@ module ImOrder
   class IncompleteOrder < StandardError
   end
 
-  class NotVoidable < StandardError
+  class OrderNotVoidable < StandardError
   end
 
   ### PNB


### PR DESCRIPTION
J'ai vérifié, NotVoidable n'était utilisé nul part donc il était plus simple de corriger le nom ici.